### PR TITLE
Source Amazon Seller Partner: Fix GET_VENDOR_TRAFFIC_REPORT when reportPeriod=DAY

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
+++ b/airbyte-integrations/connectors/source-amazon-seller-partner/source_amazon_seller_partner/streams.py
@@ -854,6 +854,8 @@ class VendorInventoryReports(IncrementalAnalyticsStream):
 class VendorTrafficReport(IncrementalAnalyticsStream):
     name = "GET_VENDOR_TRAFFIC_REPORT"
     result_key = "trafficByAsin"
+    availability_sla_days = 3
+    fixed_period_in_days = 1
 
 
 class SellerAnalyticsSalesAndTrafficReports(IncrementalAnalyticsStream):


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->

issue: https://github.com/airbytehq/airbyte/issues/37729

## How
<!--
* Describe how code changes achieve the solution.
-->

Added `availablity_sla_days=3` and `fixed_period_in_days=1` to ensure that all data in the lookback window can be fetched and that `dataEndTime` doesn't violate Amazon Vendor Central's SLA, which is 72 hours after the close of the period.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

streams.py

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

Syncing `GET_VENDOR_TRAFFIC_REPORT` will not result in errors

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
